### PR TITLE
Implementación de la gestión de estado de turno (parte D)

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -242,3 +242,33 @@ def cancelar_turno(db: Session, turno_id: int):
     db.refresh(turno)
     return turno
 
+# >>> CRUD de turnos (parte D) <<<
+
+def cancelar_turno(db: Session, turno_id: int):
+    turno = db.query(models.Turno).filter(models.Turno.id == turno_id).first()
+    if not turno:
+        raise HTTPException(status_code=404, detail="Turno no encontrado")
+    
+    # No se puede modificar si ya está cancelado o asistido
+    if turno.estado in ["cancelado", "asistido"]:
+        raise HTTPException(status_code=400, detail="No se puede cancelar un turno ya cancelado o asistido")
+    
+    turno.estado = "cancelado"
+    db.commit()
+    db.refresh(turno)
+    return turno
+
+
+def confirmar_turno(db: Session, turno_id: int):
+    turno = db.query(models.Turno).filter(models.Turno.id == turno_id).first()
+    if not turno:
+        raise HTTPException(status_code=404, detail="Turno no encontrado")
+    
+    # No se puede modificar si ya está cancelado o asistido
+    if turno.estado in ["cancelado", "asistido"]:
+        raise HTTPException(status_code=400, detail="No se puede confirmar un turno cancelado o asistido")
+    
+    turno.estado = "confirmado"
+    db.commit()
+    db.refresh(turno)
+    return turno

--- a/crud.py
+++ b/crud.py
@@ -224,3 +224,21 @@ def get_turnos_disponibles(db: Session, fecha: date):
     horarios_disponibles = [h.strftime("%H:%M") for h in horarios if h not in horas_ocupadas]
     
     return {"fecha": fecha, "horarios_disponibles": horarios_disponibles}
+
+
+# >>> CRUD de turnos (parte D) <<<
+
+def cancelar_turno(db: Session, turno_id: int):
+    turno = db.query(models.Turno).filter(models.Turno.id == turno_id).first()
+    if not turno:
+        raise HTTPException(status_code=404, detail="Turno no encontrado")
+    
+    # No se puede modificar si ya está cancelado o asistido
+    if turno.estado in ["cancelado", "asistido"]:
+        raise HTTPException(status_code=400, detail="No se puede cancelar un turno ya cancelado o asistido")
+    
+    turno.estado = "cancelado"
+    db.commit()
+    db.refresh(turno)
+    return turno
+

--- a/main.py
+++ b/main.py
@@ -83,3 +83,13 @@ def turnos_disponibles(fecha: str = Query(..., description="Fecha en formato YYY
         raise HTTPException(status_code=400, detail="Formato de fecha inválido. Debe ser YYYY-MM-DD")
     
     return crud.get_turnos_disponibles(db, fecha_obj)
+
+# >>> Endpoints de gestion de estado de turno <<< (PARTE D)
+
+@app.put("/turnos/{turno_id}/cancelar", response_model=schemas.Turno)
+def cancelar_turno_endpoint(turno_id: int, db: Session = Depends(get_db)):
+    return crud.cancelar_turno(db, turno_id)
+
+@app.put("/turnos/{turno_id}/confirmar", response_model=schemas.Turno)
+def confirmar_turno_endpoint(turno_id: int, db: Session = Depends(get_db)):
+    return crud.confirmar_turno(db, turno_id)

--- a/main.py
+++ b/main.py
@@ -71,7 +71,7 @@ def eliminar_turno(turno_id: int, db: Session = Depends(get_db)):
     return crud.delete_turno(db, turno_id)
 
 @app.put("/turnos/{turno_id}", response_model=schemas.Turno, tags=["Turnos"])
-def update_turno(db: Session, turno_id: int, turno: schemas.TurnoUpdate):
+def update_turno(turno_id: int, turno: schemas.TurnoUpdate, db: Session = Depends(get_db)):
     db_turno = db.query(models.Turno).filter(models.Turno.id == turno_id).first()
     if not db_turno:
         raise HTTPException(status_code=404, detail="Turno no encontrado")
@@ -88,9 +88,6 @@ def update_turno(db: Session, turno_id: int, turno: schemas.TurnoUpdate):
     db.commit()
     db.refresh(db_turno)
     return db_turno
-
-
-
 
 @app.get("/turnos-disponibles", tags=["Turnos"])
 def turnos_disponibles(fecha: str = Query(..., description="Fecha en formato YYYY-MM-DD"), db: Session = Depends(get_db)):

--- a/main.py
+++ b/main.py
@@ -71,8 +71,25 @@ def eliminar_turno(turno_id: int, db: Session = Depends(get_db)):
     return crud.delete_turno(db, turno_id)
 
 @app.put("/turnos/{turno_id}", response_model=schemas.Turno, tags=["Turnos"])
-def actualizar_turno(turno_id: int, turno: schemas.TurnoUpdate, db: Session = Depends(get_db)):
-    return crud.update_turno(db, turno_id, turno)
+def update_turno(db: Session, turno_id: int, turno: schemas.TurnoUpdate):
+    db_turno = db.query(models.Turno).filter(models.Turno.id == turno_id).first()
+    if not db_turno:
+        raise HTTPException(status_code=404, detail="Turno no encontrado")
+
+    update_data = turno.dict(exclude_unset=True)
+
+    #No permitir modificar el estado desde este endpoint
+    if "estado" in update_data:
+        update_data.pop("estado")
+
+    for key, value in update_data.items():
+        setattr(db_turno, key, value)
+
+    db.commit()
+    db.refresh(db_turno)
+    return db_turno
+
+
 
 
 @app.get("/turnos-disponibles", tags=["Turnos"])

--- a/main.py
+++ b/main.py
@@ -90,6 +90,7 @@ def turnos_disponibles(fecha: str = Query(..., description="Fecha en formato YYY
 def cancelar_turno_endpoint(turno_id: int, db: Session = Depends(get_db)):
     return crud.cancelar_turno(db, turno_id)
 
+
 @app.put("/turnos/{turno_id}/confirmar", response_model=schemas.Turno)
 def confirmar_turno_endpoint(turno_id: int, db: Session = Depends(get_db)):
     return crud.confirmar_turno(db, turno_id)


### PR DESCRIPTION
### Cambios realizados
- Agregadas funciones `cancelar_turno` y `confirmar_turno` en `crud.py`.
- Nuevos endpoints `PUT /turnos/{id}/cancelar` y `PUT /turnos/{id}/confirmar` en `main.py`.
- Se restringió `update_turno` para que no permita modificar el campo `estado`.
- 
### Reglas de negocio aplicadas
- No se puede modificar un turno ya cancelado o asistido.
- No se pueden eliminar ni cancelar turnos asistidos.
- Turnos cancelados liberan el horario (eliminación lógica).

### Testing
Se realizaron pruebas en Postman verificando:
- Cancelación correcta de turno pendiente.
- Confirmación correcta de turno pendiente.
- Errores adecuados al cancelar/confirmar turnos ya cancelados o asistidos.
